### PR TITLE
bug fix in aij.py

### DIFF
--- a/glowing_waffles/io/aij.py
+++ b/glowing_waffles/io/aij.py
@@ -79,7 +79,7 @@ class Star(object):
 
     @property
     def ra(self):
-        return self._table['RA'] / 24 * 360 * u.degree
+        return self._table['RA'] / 24 * 360 * u.hourangle
 
     @property
     def dec(self):


### PR DESCRIPTION
The ra(self) method was assuming table RA data was in degrees but AIJ outputs in hour angle.
